### PR TITLE
Add test for not found endpoint

### DIFF
--- a/src/server/__tests__/notFoundEndpoint.test.ts
+++ b/src/server/__tests__/notFoundEndpoint.test.ts
@@ -1,0 +1,22 @@
+import request from "supertest";
+import app from "../app.js";
+
+describe("Given the GET '/paquirri' endpoint (which does not exist)", () => {
+  describe("When it receives a request", () => {
+    test("Then it should respond with a 404 status code and an 'Endpoint not found' error", async () => {
+      interface Body {
+        error: string;
+      }
+
+      const expectedStatusCode = 404;
+      const expectedError = "Endpoint not found";
+
+      const response = await request(app).get("/paquirri");
+
+      const responseBody = response.body as Body;
+
+      expect(response.status).toBe(expectedStatusCode);
+      expect(responseBody.error).toBe(expectedError);
+    });
+  });
+});


### PR DESCRIPTION
Add test for not found endpoint, using `GET` method and a non-existing path like `/paquirri`